### PR TITLE
Codec fix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -54,10 +54,6 @@ jobs:
         run: |
           black --check --verbose sdks/python --extend-exclude _pb2.py
 
-      - name: Linting connectors
-        run: |
-          black --check --verbose connectors/*/bin/* --force-exclude .odvd
-
 
   python-sdk-testing:
     runs-on: ubuntu-latest

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keelson-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "index.js",
   "files": [

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -19,7 +19,7 @@ def read(fname):
 
 setup(
     name="keelson",
-    version="0.3.0",
+    version="0.3.1",
     license="Apache License 2.0",
     description="A python Software Development Kit for keelson",
     long_description=read("README.md"),


### PR DESCRIPTION
Codecs to and from text/base64 is now restricted to subject 'raw' and wraps/unwraps to/from TimestampedBytes to ensure conformance with the keelson API spec.

Close #41 