### PR TITLE
Threading up `rtsp`

### DIFF
--- a/connectors/rtsp/bin/rtsp
+++ b/connectors/rtsp/bin/rtsp
@@ -15,6 +15,7 @@ import logging
 import argparse
 import warnings
 from collections import deque
+from threading import Thread, Event
 
 import cv2
 import numpy
@@ -72,80 +73,111 @@ def to_frames(session: zenoh.Session, args: argparse.Namespace):
 
     logging.info("Native framerate of stream: %s", fps)
 
-    buffer = deque(maxlen=30)
+    buffer = deque(maxlen=1)
+    close_down = Event()
 
-    while cap.isOpened():
-        loop_beginning = time.time()
-        ret, img = cap.read()
-        ingress_timestamp = time.time_ns()
+    def _capturer():
+        while cap.isOpened() and not close_down.is_set():
+            ret, img = cap.read()
+            ingress_timestamp = time.time_ns()
 
-        if not ret:
-            logging.error("No frames returned from the stream. Exiting!")
-            sys.exit(1)
+            if not ret:
+                logging.error("No frames returned from the stream. Exiting!")
+                return
 
-        logging.info("Got new frame, at time: %d", ingress_timestamp)
+            logging.info("Got new frame, at time: %d", ingress_timestamp)
 
-        height, width, _ = img.shape
-        logging.debug("with height: %d, width: %d", height, width)
+            height, width, _ = img.shape
+            logging.debug("with height: %d, width: %d", height, width)
 
-        logging.debug("Processing raw frame")
+            buffer.append((ingress_timestamp, img))
 
-        data = img.tobytes()
-        width_step = len(data) // height
-        logging.debug(
-            "Frame total byte length: %d, widthstep: %d", len(data), width_step
-        )
+    # Start capture thread
+    t = Thread(target=_capturer)
+    t.daemon = True
+    t.start()
 
-        # Create payload for raw image
-        payload = RawImage()
-        payload.timestamp.FromNanoseconds(ingress_timestamp)
-        if args.frame_id is not None:
-            payload.frame_id = args.frame_id
-        payload.width = width
-        payload.height = height
-        payload.encoding = "bgr8"  # Default in OpenCV
-        payload.step = width_step
-        payload.data = data
+    try:
+        previous = time.time()
+        while True:
+            try:
+                ingress_timestamp, img = buffer.pop()
+            except IndexError:
+                time.sleep(0.01)
+                continue
 
-        serialized_payload = payload.SerializeToString()
-        logging.debug("Payload created using 'foxglove.RawImage'")
+            logging.debug("Processing raw frame")
 
-        envelope = keelson.enclose(serialized_payload)
-        logging.debug("...enclosed into envelope.")
+            height, width, _ = img.shape
+            data = img.tobytes()
 
-        raw_publisher.put(envelope)
-        logging.info("...published to zenoh!")
-
-        if args.compress is not None:
-            logging.debug("Compressing frame...")
-            _, compressed_img = cv2.imencode(  # pylint: disable=no-member
-                MCAP_TO_OPENCV_ENCODINGS[args.compress], img
+            width_step = len(data) // height
+            logging.debug(
+                "Frame total byte length: %d, widthstep: %d", len(data), width_step
             )
-            compressed_img = numpy.asarray(compressed_img)
-            data = compressed_img.tobytes()
 
-            payload = CompressedImage()
+            # Create payload for raw image
+            payload = RawImage()
+            payload.timestamp.FromNanoseconds(ingress_timestamp)
             if args.frame_id is not None:
                 payload.frame_id = args.frame_id
+            payload.width = width
+            payload.height = height
+            payload.encoding = "bgr8"  # Default in OpenCV
+            payload.step = width_step
             payload.data = data
-            payload.format = args.compress
 
             serialized_payload = payload.SerializeToString()
-            logging.debug("Payload created using 'foxglove.CompressedImage'")
+            logging.debug("Payload created using 'foxglove.RawImage'")
 
             envelope = keelson.enclose(serialized_payload)
             logging.debug("...enclosed into envelope.")
 
-            compressed_publisher.put(envelope)
+            raw_publisher.put(envelope)
             logging.info("...published to zenoh!")
 
-        # Doing some calculations to see if we manage to keep up with the framerate
-        loop_execution_time = time.time() - loop_beginning
-        buffer.append(loop_execution_time)
+            if args.compress is not None:
+                logging.debug("Compressing frame...")
+                _, compressed_img = cv2.imencode(  # pylint: disable=no-member
+                    MCAP_TO_OPENCV_ENCODINGS[args.compress], img
+                )
+                compressed_img = numpy.asarray(compressed_img)
+                data = compressed_img.tobytes()
 
-        logging.info("Current framerate: %.2f", len(buffer) / sum(buffer))
+                payload = CompressedImage()
+                if args.frame_id is not None:
+                    payload.frame_id = args.frame_id
+                payload.data = data
+                payload.format = args.compress
 
-    logging.error("VideoCapture is not open!")
+                serialized_payload = payload.SerializeToString()
+                logging.debug("Payload created using 'foxglove.CompressedImage'")
+
+                envelope = keelson.enclose(serialized_payload)
+                logging.debug("...enclosed into envelope.")
+
+                compressed_publisher.put(envelope)
+                logging.info("...published to zenoh!")
+
+            # Doing some calculations to see if we manage to keep up with the framerate
+            now = time.time()
+            processing_frame_rate = now - previous
+            previous = now
+
+            logging.info(
+                "Processing framerate: %.2f (%d%% of native)",
+                processing_frame_rate,
+                100 * (processing_frame_rate / fps),
+            )
+
+    except KeyboardInterrupt:
+        logging.info("Closing down on user request!")
+
+        logging.debug("Joining capturer thread...")
+        close_down.set()
+        t.join()
+
+        logging.debug("Done! Good bye :)")
 
 
 # pylint: disable=notimplemented-raised


### PR DESCRIPTION
Moves reading of new frames from the capture object to a separate thread to hopefully ensure we always have the latest frame to process (drops all others).